### PR TITLE
Fix missing newline character

### DIFF
--- a/src/createEthApp.ts
+++ b/src/createEthApp.ts
@@ -38,6 +38,7 @@ export async function createEthApp({ appPath, template }: { appPath: string; tem
   const isOnline = await getOnline();
   const originalDirectory = process.cwd();
 
+  console.log();
   console.log(`Creating a new Ethereum-powered React app in ${chalk.green(root)}.`);
   console.log();
 


### PR DESCRIPTION
I noticed that the previous line runs into the back of `Creating a new Ethereum-powered React app in ${chalk.green(root)}.` when it's printed. This PR prevents this.