### PR TITLE
fix:  issue #17 workspaces error

### DIFF
--- a/src/helpers/yarn.ts
+++ b/src/helpers/yarn.ts
@@ -14,8 +14,9 @@ export function shouldUseYarn(): void {
 }
 
 export function shouldUseYarnWorkspaces(): void {
-  const result: string = execSync("yarnpkg config get workspaces-experimental", { encoding: "utf8" });
-  if (result.replace(os.EOL, "") !== "true") {
+  const yarnVersion: string = execSync("yarnpkg --version", { encoding: "utf8" });
+  const workspacesFlag: string = execSync("yarnpkg config get workspaces-experimental", { encoding: "utf8" });
+  if (yarnVersion.startsWith("0") && !workspacesFlag.startsWith("true")) {
     console.error(
       "The Yarn Workspaces feature is necessary for Create Eth App. Please enable it by running this command:",
     );


### PR DESCRIPTION
Fixes #17. 

I used `startsWith()` for both checks because:
1. for the version test it doesn't require adding semver as an extra dependency, and
2. for the flag test it's newline agnostic and therefore OS agnostic.

Test with yarn 0.28 and 1.22 on MacOS. Not tested on Windows.
