### PR TITLE
WIP: Get rid of installation warnings

### DIFF
--- a/src/helpers/install.ts
+++ b/src/helpers/install.ts
@@ -23,7 +23,7 @@ export function install(root: string, dependencies: string[] | null, { isOnline 
 
     const child = spawn(command, args, {
       env: { ...process.env, ADBLOCK: "1", DISABLE_OPENCOLLECTIVE: "1" },
-      stdio: "inherit",
+      stdio: ["inherit", "inherit", "ignore"],
     });
     child.on("close", (code: number) => {
       if (code !== 0) {


### PR DESCRIPTION
I've set the child process running the `yarn install` command to ignore anything on stderr so that package warnings don't get printed to the console. It's a little brute force but it doesn't seem like yarn allows silencing of package warnings specifically.

![Screenshot_2020-05-18_14-10-08](https://user-images.githubusercontent.com/15848336/82216896-83072a00-9911-11ea-9596-e3680a2cca68.png)

The "fsevents" info lines are a bit trickier to hide as they're on stdout so would require parsing to get rid of without nuking the entire yarn output.

closes #22 