### PR TITLE
Update .gitignore so that node_modules is ignored

### DIFF
--- a/templates/react/default/.gitignore
+++ b/templates/react/default/.gitignore
@@ -1,8 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
-/.pnp
+node_modules
+.pnp
 .pnp.js
 
 # testing


### PR DESCRIPTION
A preceding slash has crept into the .gitignore file so the `node_modules` folder isn't ignored.

sanity check from @PaulRBerg: as this is a change on the template side we don't need to take any further action than merging to develop right?