### PR TITLE
Add IPFS deployment script to templates

### DIFF
--- a/handlebars/react/package.json.hbs
+++ b/handlebars/react/package.json.hbs
@@ -19,6 +19,7 @@
     {{/with }}
     "react-app:build": "yarn workspace {{ orgName }}/react-app build",
     "react-app:eject": "yarn workspace {{ orgName }}/react-app eject",
+    "react-app:ipfs": "yarn workspace {{ orgName }}/react-app ipfs",
     "react-app:start": "yarn workspace {{ orgName }}/react-app start",
     "react-app:test": "yarn workspace {{ orgName }}/react-app test"
   },

--- a/handlebars/react/packages/react-app/package.json.hbs
+++ b/handlebars/react/packages/react-app/package.json.hbs
@@ -30,9 +30,11 @@
     "apollo-boost": "^0.4.7",
     "apollo-client": "^2.6.8",
     "apollo-utilities": "^1.3.3",
+    "chalk": "^4.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-flowtype": "^4.6.0",
     "graphql": "^14.6.0",
+    "ipfs-http-client": "^45.0.0",
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "react-scripts": "3.4.1",
@@ -45,6 +47,7 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "test": "react-scripts test"
+    "test": "react-scripts test",
+    "ipfs": "node scripts/ipfs.js"
   }
 }

--- a/handlebars/react/packages/react-app/package.json.hbs
+++ b/handlebars/react/packages/react-app/package.json.hbs
@@ -1,6 +1,7 @@
 {
   "name": "{{ packageName }}",
   "version": "1.0.0",
+  "homepage": "./",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/handlebars/react/packages/react-app/package.json.hbs
+++ b/handlebars/react/packages/react-app/package.json.hbs
@@ -47,8 +47,8 @@
   "scripts": {
     "build": "react-scripts build",
     "eject": "react-scripts eject",
+    "ipfs": "node scripts/ipfs.js",
     "start": "react-scripts start",
-    "test": "react-scripts test",
-    "ipfs": "node scripts/ipfs.js"
+    "test": "react-scripts test"
   }
 }

--- a/handlebars/react/packages/react-app/package.json.hbs
+++ b/handlebars/react/packages/react-app/package.json.hbs
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "ipfs": "node scripts/ipfs.js",
+    "ipfs": "yarn build && node scripts/ipfs.js",
     "start": "react-scripts start",
     "test": "react-scripts test"
   }

--- a/handlebars/react/packages/react-app/scripts/ipfs.js
+++ b/handlebars/react/packages/react-app/scripts/ipfs.js
@@ -1,0 +1,88 @@
+const ipfsAPI = require("ipfs-http-client");
+const chalk = require("chalk");
+const { clearLine } = require("readline");
+
+const { globSource } = ipfsAPI;
+
+const infura = { host: "ipfs.infura.io", port: "5001", protocol: "https" };
+// run your own ipfs daemon: https://docs.ipfs.io/how-to/command-line-quick-start/#install-ipfs
+// const localhost = { host: "localhost", port: "5001", protocol: "http" };
+
+const ipfs = ipfsAPI(infura);
+
+const ipfsGateway = "https://ipfs.io/ipfs/";
+
+const addOptions = {
+  pin: true,
+};
+
+const pushDirectoryToIPFS = async path => {
+  try {
+    const response = await ipfs.add(globSource(path, { recursive: true }), addOptions);
+    return response;
+  } catch (e) {
+    return {};
+  }
+};
+
+const publishHashToIPNS = async ipfsHash => {
+  try {
+    const response = await ipfs.name.publish(`/ipfs/${ipfsHash}`);
+    return response;
+  } catch (e) {
+    return {};
+  }
+};
+
+const nodeMayAllowPublish = ipfsClient => {
+  // You must have your own IPFS node in order to publish an IPNS name
+  // This contains a blacklist of known nodes which do not allow users to publish IPNS names.
+  const nonPublishingNodes = ["ipfs.infura.io"];
+  const { host } = ipfsClient.getEndpointConfig();
+  return !nonPublishingNodes.some(nodeUrl => host.includes(nodeUrl));
+};
+
+const deploy = async () => {
+  console.log("🛰  Sending to IPFS...");
+  const { cid } = await pushDirectoryToIPFS("./build");
+  if (!cid) {
+    console.log(`📡 App deployment failed`);
+    return false;
+  }
+  console.log(`📡 App deployed to IPFS with hash: ${chalk.cyan(cid.toString())}`);
+
+  console.log();
+
+  let ipnsName = "";
+  if (nodeMayAllowPublish(ipfs)) {
+    console.log(`✍️  Publishing /ipfs/${cid.toString()} to IPNS...`);
+    process.stdout.write("   Publishing to IPNS can take up to roughly two minutes.\r");
+    ipnsName = (await publishHashToIPNS(cid.toString())).name;
+    clearLine(process.stdout, 0);
+    if (!ipnsName) {
+      console.log("   Publishing IPNS name on node failed.");
+    }
+    console.log(`🔖 App published to IPNS with name: ${chalk.cyan(ipnsName)}`);
+    console.log();
+  }
+
+  console.log("🚀 Deployment to IPFS complete!");
+  console.log();
+
+  console.log(`Use the link${ipnsName && "s"} below to access your app:`);
+  console.log(`   IPFS: ${chalk.cyan(`${ipfsGateway}${cid.toString()}`)}`);
+  if (ipnsName) {
+    console.log(`   IPNS: ${chalk.cyan(`${ipfsGateway}${ipnsName}`)}`);
+    console.log();
+    console.log(
+      "Each new deployment will have a unique IPFS hash while the IPNS name will always point at the most recent deployment.",
+    );
+    console.log(
+      "It is recommended that you share the IPNS link so that people always see the newest version of your app.",
+    );
+  }
+  console.log();
+  return true;
+};
+
+deploy();

--- a/handlebars/react/packages/react-app/scripts/ipfs.js
+++ b/handlebars/react/packages/react-app/scripts/ipfs.js
@@ -33,7 +33,7 @@ async function publishHashToIpns(ipfsHash) {
   }
 }
 
-async function nodeMayAllowPublish(ipfsClient) {
+function nodeMayAllowPublish(ipfsClient) {
   // You must have your own IPFS node in order to publish an IPNS name
   // This contains a blacklist of known nodes which do not allow users to publish IPNS names.
   const nonPublishingNodes = ["ipfs.infura.io"];
@@ -75,7 +75,7 @@ async function nodeMayAllowPublish(ipfsClient) {
   console.log("🚀 Deployment to IPFS complete!");
   console.log();
 
-  console.log(`🌐 Use the link${ipnsName && "s"} below to access your app:`);
+  console.log(`🌐 Use the link${ipnsName ? "s" : ""} below to access your app:`);
   const link = ipfsGateway + cid.toString();
   console.log(`   IPFS: ${chalk.cyan(link)}`);
 

--- a/handlebars/react/packages/react-app/scripts/ipfs.js
+++ b/handlebars/react/packages/react-app/scripts/ipfs.js
@@ -1,67 +1,73 @@
-const ipfsAPI = require("ipfs-http-client");
 const chalk = require("chalk");
+const ipfsApi = require("ipfs-http-client");
 const { clearLine } = require("readline");
 
-const { globSource } = ipfsAPI;
+const { globSource } = ipfsApi;
 
 const infura = { host: "ipfs.infura.io", port: "5001", protocol: "https" };
-// run your own ipfs daemon: https://docs.ipfs.io/how-to/command-line-quick-start/#install-ipfs
+// Run your own ipfs daemon: https://docs.ipfs.io/how-to/command-line-quick-start/#install-ipfs
 // const localhost = { host: "localhost", port: "5001", protocol: "http" };
 
-const ipfs = ipfsAPI(infura);
-
+const ipfs = ipfsApi(infura);
 const ipfsGateway = "https://ipfs.io/ipfs/";
 
 const addOptions = {
   pin: true,
 };
 
-const pushDirectoryToIPFS = async path => {
+async function pushDirectoryToIpfs(path) {
   try {
     const response = await ipfs.add(globSource(path, { recursive: true }), addOptions);
     return response;
   } catch (e) {
     return {};
   }
-};
+}
 
-const publishHashToIPNS = async ipfsHash => {
+async function publishHashToIpns(ipfsHash) {
   try {
     const response = await ipfs.name.publish(`/ipfs/${ipfsHash}`);
     return response;
   } catch (e) {
     return {};
   }
-};
+}
 
-const nodeMayAllowPublish = ipfsClient => {
+async function nodeMayAllowPublish(ipfsClient) {
   // You must have your own IPFS node in order to publish an IPNS name
   // This contains a blacklist of known nodes which do not allow users to publish IPNS names.
   const nonPublishingNodes = ["ipfs.infura.io"];
   const { host } = ipfsClient.getEndpointConfig();
-  return !nonPublishingNodes.some(nodeUrl => host.includes(nodeUrl));
-};
 
-const deploy = async () => {
+  return !nonPublishingNodes.some(nodeUrl => {
+    return host.includes(nodeUrl);
+  });
+}
+
+(async function() {
   console.log("🛰  Sending to IPFS...");
-  const { cid } = await pushDirectoryToIPFS("./build");
+  console.log();
+
+  const { cid } = await pushDirectoryToIpfs("./build");
   if (!cid) {
     console.log(`📡 App deployment failed`);
     return false;
   }
-  console.log(`📡 App deployed to IPFS with hash: ${chalk.cyan(cid.toString())}`);
 
+  console.log(`📡 App deployed to IPFS with hash: ${chalk.cyan(cid.toString())}`);
   console.log();
 
   let ipnsName = "";
   if (nodeMayAllowPublish(ipfs)) {
     console.log(`✍️  Publishing /ipfs/${cid.toString()} to IPNS...`);
     process.stdout.write("   Publishing to IPNS can take up to roughly two minutes.\r");
-    ipnsName = (await publishHashToIPNS(cid.toString())).name;
+    ipnsName = (await publishHashToIpns(cid.toString())).name;
     clearLine(process.stdout, 0);
+
     if (!ipnsName) {
       console.log("   Publishing IPNS name on node failed.");
     }
+
     console.log(`🔖 App published to IPNS with name: ${chalk.cyan(ipnsName)}`);
     console.log();
   }
@@ -69,10 +75,13 @@ const deploy = async () => {
   console.log("🚀 Deployment to IPFS complete!");
   console.log();
 
-  console.log(`Use the link${ipnsName && "s"} below to access your app:`);
-  console.log(`   IPFS: ${chalk.cyan(`${ipfsGateway}${cid.toString()}`)}`);
+  console.log(`🌐 Use the link${ipnsName && "s"} below to access your app:`);
+  const link = ipfsGateway + cid.toString();
+  console.log(`   IPFS: ${chalk.cyan(link)}`);
+
   if (ipnsName) {
-    console.log(`   IPNS: ${chalk.cyan(`${ipfsGateway}${ipnsName}`)}`);
+    const ipnsUrl = `${ipfsGateway}${ipnsName}`;
+    console.log(`   IPNS: ${chalk.cyan(ipnsUrl)}`);
     console.log();
     console.log(
       "Each new deployment will have a unique IPFS hash while the IPNS name will always point at the most recent deployment.",
@@ -83,6 +92,4 @@ const deploy = async () => {
   }
   console.log();
   return true;
-};
-
-deploy();
+})();

--- a/handlebars/vue/package.json.hbs
+++ b/handlebars/vue/package.json.hbs
@@ -18,6 +18,7 @@
     {{/each }}
     {{/with }}
     "vue-app:build": "yarn workspace {{ orgName }}/vue-app build",
+    "vue-app:ipfs": "yarn workspace {{ orgName }}/vue-app ipfs",
     "vue-app:lint": "yarn workspace {{ orgName }}/vue-app lint",
     "vue-app:serve": "yarn workspace {{ orgName }}/vue-app serve"
   },

--- a/handlebars/vue/packages/vue-app/package.json.hbs
+++ b/handlebars/vue/packages/vue-app/package.json.hbs
@@ -22,10 +22,12 @@
     "apollo-link-http": "^1.5.17",
     "babel-eslint": "^10.1.0",
     "core-js": "^3.6.4",
+    "chalk": "^4.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^6.2.2",
     "graphql": "^15.0.0",
     "graphql-tag": "^2.10.3",
+    "ipfs-http-client": "^45.0.0",
     "vue": "^2.6.11",
     "vue-apollo": "^3.0.3",
     "vue-template-compiler": "^2.6.11"
@@ -34,6 +36,7 @@
   "scripts": {
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "serve": "vue-cli-service serve"
+    "serve": "vue-cli-service serve",
+    "ipfs": "node scripts/ipfs.js"
   }
 }

--- a/handlebars/vue/packages/vue-app/package.json.hbs
+++ b/handlebars/vue/packages/vue-app/package.json.hbs
@@ -35,8 +35,8 @@
   "private": true,
   "scripts": {
     "build": "vue-cli-service build",
+    "ipfs": "node scripts/ipfs.js",
     "lint": "vue-cli-service lint",
-    "serve": "vue-cli-service serve",
-    "ipfs": "node scripts/ipfs.js"
+    "serve": "vue-cli-service serve"
   }
 }

--- a/handlebars/vue/packages/vue-app/package.json.hbs
+++ b/handlebars/vue/packages/vue-app/package.json.hbs
@@ -35,7 +35,7 @@
   "private": true,
   "scripts": {
     "build": "vue-cli-service build",
-    "ipfs": "node scripts/ipfs.js",
+    "ipfs": "yarn build && node scripts/ipfs.js",
     "lint": "vue-cli-service lint",
     "serve": "vue-cli-service serve"
   }

--- a/handlebars/vue/packages/vue-app/scripts/ipfs.js
+++ b/handlebars/vue/packages/vue-app/scripts/ipfs.js
@@ -33,7 +33,7 @@ async function publishHashToIpns(ipfsHash) {
   }
 }
 
-async function nodeMayAllowPublish(ipfsClient) {
+function nodeMayAllowPublish(ipfsClient) {
   // You must have your own IPFS node in order to publish an IPNS name
   // This contains a blacklist of known nodes which do not allow users to publish IPNS names.
   const nonPublishingNodes = ["ipfs.infura.io"];
@@ -75,7 +75,7 @@ async function nodeMayAllowPublish(ipfsClient) {
   console.log("🚀 Deployment to IPFS complete!");
   console.log();
 
-  console.log(`🌐 Use the link${ipnsName && "s"} below to access your app:`);
+  console.log(`🌐 Use the link${ipnsName ? "s" : ""} below to access your app:`);
   const link = ipfsGateway + cid.toString();
   console.log(`   IPFS: ${chalk.cyan(link)}`);
 

--- a/handlebars/vue/packages/vue-app/scripts/ipfs.js
+++ b/handlebars/vue/packages/vue-app/scripts/ipfs.js
@@ -1,0 +1,88 @@
+const ipfsAPI = require("ipfs-http-client");
+const chalk = require("chalk");
+const { clearLine } = require("readline");
+
+const { globSource } = ipfsAPI;
+
+const infura = { host: "ipfs.infura.io", port: "5001", protocol: "https" };
+// run your own ipfs daemon: https://docs.ipfs.io/how-to/command-line-quick-start/#install-ipfs
+// const localhost = { host: "localhost", port: "5001", protocol: "http" };
+
+const ipfs = ipfsAPI(infura);
+
+const ipfsGateway = "https://ipfs.io/ipfs/";
+
+const addOptions = {
+  pin: true,
+};
+
+const pushDirectoryToIPFS = async path => {
+  try {
+    const response = await ipfs.add(globSource(path, { recursive: true }), addOptions);
+    return response;
+  } catch (e) {
+    return {};
+  }
+};
+
+const publishHashToIPNS = async ipfsHash => {
+  try {
+    const response = await ipfs.name.publish(`/ipfs/${ipfsHash}`);
+    return response;
+  } catch (e) {
+    return {};
+  }
+};
+
+const nodeMayAllowPublish = ipfsClient => {
+  // You must have your own IPFS node in order to publish an IPNS name
+  // This contains a blacklist of known nodes which do not allow users to publish IPNS names.
+  const nonPublishingNodes = ["ipfs.infura.io"];
+  const { host } = ipfsClient.getEndpointConfig();
+  return !nonPublishingNodes.some(nodeUrl => host.includes(nodeUrl));
+};
+
+const deploy = async () => {
+  console.log("🛰  Sending to IPFS...");
+  const { cid } = await pushDirectoryToIPFS("./dist");
+  if (!cid) {
+    console.log(`📡 App deployment failed`);
+    return false;
+  }
+  console.log(`📡 App deployed to IPFS with hash: ${chalk.cyan(cid.toString())}`);
+
+  console.log();
+
+  let ipnsName = "";
+  if (nodeMayAllowPublish(ipfs)) {
+    console.log(`✍️  Publishing /ipfs/${cid.toString()} to IPNS...`);
+    process.stdout.write("   Publishing to IPNS can take up to roughly two minutes.\r");
+    ipnsName = (await publishHashToIPNS(cid.toString())).name;
+    clearLine(process.stdout, 0);
+    if (!ipnsName) {
+      console.log("   Publishing IPNS name on node failed.");
+    }
+    console.log(`🔖 App published to IPNS with name: ${chalk.cyan(ipnsName)}`);
+    console.log();
+  }
+
+  console.log("🚀 Deployment to IPFS complete!");
+  console.log();
+
+  console.log(`Use the link${ipnsName && "s"} below to access your app:`);
+  console.log(`   IPFS: ${chalk.cyan(`${ipfsGateway}${cid.toString()}`)}`);
+  if (ipnsName) {
+    console.log(`   IPNS: ${chalk.cyan(`${ipfsGateway}${ipnsName}`)}`);
+    console.log();
+    console.log(
+      "Each new deployment will have a unique IPFS hash while the IPNS name will always point at the most recent deployment.",
+    );
+    console.log(
+      "It is recommended that you share the IPNS link so that people always see the newest version of your app.",
+    );
+  }
+  console.log();
+  return true;
+};
+
+deploy();

--- a/handlebars/vue/packages/vue-app/scripts/ipfs.js
+++ b/handlebars/vue/packages/vue-app/scripts/ipfs.js
@@ -1,67 +1,73 @@
-const ipfsAPI = require("ipfs-http-client");
 const chalk = require("chalk");
+const ipfsApi = require("ipfs-http-client");
 const { clearLine } = require("readline");
 
-const { globSource } = ipfsAPI;
+const { globSource } = ipfsApi;
 
 const infura = { host: "ipfs.infura.io", port: "5001", protocol: "https" };
-// run your own ipfs daemon: https://docs.ipfs.io/how-to/command-line-quick-start/#install-ipfs
+// Run your own ipfs daemon: https://docs.ipfs.io/how-to/command-line-quick-start/#install-ipfs
 // const localhost = { host: "localhost", port: "5001", protocol: "http" };
 
-const ipfs = ipfsAPI(infura);
-
+const ipfs = ipfsApi(infura);
 const ipfsGateway = "https://ipfs.io/ipfs/";
 
 const addOptions = {
   pin: true,
 };
 
-const pushDirectoryToIPFS = async path => {
+async function pushDirectoryToIpfs(path) {
   try {
     const response = await ipfs.add(globSource(path, { recursive: true }), addOptions);
     return response;
   } catch (e) {
     return {};
   }
-};
+}
 
-const publishHashToIPNS = async ipfsHash => {
+async function publishHashToIpns(ipfsHash) {
   try {
     const response = await ipfs.name.publish(`/ipfs/${ipfsHash}`);
     return response;
   } catch (e) {
     return {};
   }
-};
+}
 
-const nodeMayAllowPublish = ipfsClient => {
+async function nodeMayAllowPublish(ipfsClient) {
   // You must have your own IPFS node in order to publish an IPNS name
   // This contains a blacklist of known nodes which do not allow users to publish IPNS names.
   const nonPublishingNodes = ["ipfs.infura.io"];
   const { host } = ipfsClient.getEndpointConfig();
-  return !nonPublishingNodes.some(nodeUrl => host.includes(nodeUrl));
-};
 
-const deploy = async () => {
+  return !nonPublishingNodes.some(nodeUrl => {
+    return host.includes(nodeUrl);
+  });
+}
+
+(async function() {
   console.log("🛰  Sending to IPFS...");
-  const { cid } = await pushDirectoryToIPFS("./dist");
+  console.log();
+
+  const { cid } = await pushDirectoryToIpfs("./dist");
   if (!cid) {
     console.log(`📡 App deployment failed`);
     return false;
   }
-  console.log(`📡 App deployed to IPFS with hash: ${chalk.cyan(cid.toString())}`);
 
+  console.log(`📡 App deployed to IPFS with hash: ${chalk.cyan(cid.toString())}`);
   console.log();
 
   let ipnsName = "";
   if (nodeMayAllowPublish(ipfs)) {
     console.log(`✍️  Publishing /ipfs/${cid.toString()} to IPNS...`);
     process.stdout.write("   Publishing to IPNS can take up to roughly two minutes.\r");
-    ipnsName = (await publishHashToIPNS(cid.toString())).name;
+    ipnsName = (await publishHashToIpns(cid.toString())).name;
     clearLine(process.stdout, 0);
+
     if (!ipnsName) {
       console.log("   Publishing IPNS name on node failed.");
     }
+
     console.log(`🔖 App published to IPNS with name: ${chalk.cyan(ipnsName)}`);
     console.log();
   }
@@ -69,10 +75,13 @@ const deploy = async () => {
   console.log("🚀 Deployment to IPFS complete!");
   console.log();
 
-  console.log(`Use the link${ipnsName && "s"} below to access your app:`);
-  console.log(`   IPFS: ${chalk.cyan(`${ipfsGateway}${cid.toString()}`)}`);
+  console.log(`🌐 Use the link${ipnsName && "s"} below to access your app:`);
+  const link = ipfsGateway + cid.toString();
+  console.log(`   IPFS: ${chalk.cyan(link)}`);
+
   if (ipnsName) {
-    console.log(`   IPNS: ${chalk.cyan(`${ipfsGateway}${ipnsName}`)}`);
+    const ipnsUrl = `${ipfsGateway}${ipnsName}`;
+    console.log(`   IPNS: ${chalk.cyan(ipnsUrl)}`);
     console.log();
     console.log(
       "Each new deployment will have a unique IPFS hash while the IPNS name will always point at the most recent deployment.",
@@ -83,6 +92,4 @@ const deploy = async () => {
   }
   console.log();
   return true;
-};
-
-deploy();
+})();

--- a/handlebars/vue/packages/vue-app/vue.config.js
+++ b/handlebars/vue/packages/vue-app/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  publicPath: './'
+}

--- a/handlebars/vue/packages/vue-app/vue.config.js
+++ b/handlebars/vue/packages/vue-app/vue.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  publicPath: './'
-}
+  publicPath: "./",
+};

--- a/src/createEthApp.ts
+++ b/src/createEthApp.ts
@@ -11,7 +11,6 @@ import {
 } from "./helpers/frameworks";
 import {
   TemplateKey,
-  downloadAndExtractTemplate,
   hasTemplate,
   parseTemplate,
   registerHandlebarsHelpers,

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,4 +1,4 @@
-export const branch: string = "ipfs";
+export const branch: string = "develop";
 export const frameworks = ["react", "vue"] as const;
 export const templates = [
   "aave",

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,4 +1,4 @@
-export const branch: string = "develop";
+export const branch: string = "ipfs";
 export const frameworks = ["react", "vue"] as const;
 export const templates = [
   "aave",

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -44,15 +44,9 @@ const commonBespokeFiles: string[] = [
   "packages/contracts/src/abis",
 ];
 
-const reactBespokeFiles: string[] = [
-  ...commonBespokeFiles,
-  "packages/react-app/src/graphql/subgraph.js",
-];
+const reactBespokeFiles: string[] = [...commonBespokeFiles, "packages/react-app/src/graphql/subgraph.js"];
 
-const vueBespokeFiles: string[] = [
-  ...commonBespokeFiles,
-  "packages/vue-app/src/graphql/subgraph.js",
-];
+const vueBespokeFiles: string[] = [...commonBespokeFiles, "packages/vue-app/src/graphql/subgraph.js"];
 
 export const bespokeFiles: Record<FrameworkKey, Record<TemplateKey, string[]>> = {
   react: {
@@ -104,12 +98,12 @@ export async function parseTemplate(appPath: string, framework: FrameworkKey, te
     const contextFileName: string = standardFile + ".ctx";
     const contextFilePath: string = path.join(templateContextPath, contextFileName);
     const context: JSON = JSON.parse(await fs.readFile(contextFilePath, "utf-8"));
-  
+
     const hbsFileName: string = standardFile + ".hbs";
     const hbsFilePath: string = path.join(appPath, hbsFileName);
     const hbs: string = await fs.readFile(hbsFilePath, "utf-8");
     const contents: string = Handlebars.compile(hbs)(context);
-  
+
     const appFilePath: string = path.join(appPath, standardFile);
     await fs.writeFile(appFilePath, contents);
     await fs.remove(hbsFilePath);

--- a/templates/vue/synthetix/packages/vue-app/src/graphql/subgraph.js
+++ b/templates/vue/synthetix/packages/vue-app/src/graphql/subgraph.js
@@ -1,6 +1,5 @@
 import gql from "graphql-tag";
 
-
 // See more example queries on https://thegraph.com/explorer/subgraph/synthetixio-team/synthetix
 const GET_TRANSFERS = gql`
   {


### PR DESCRIPTION
I've added the IPFS deploy script and put in the `homepage: "./"` IPFS fix for both React and Vue templates.

I've tested this for both frameworks and it's displaying ok so it should be good to go.