### PR TITLE
Make Vue component name valid

### DIFF
--- a/handlebars/vue/packages/vue-app/src/App.vue
+++ b/handlebars/vue/packages/vue-app/src/App.vue
@@ -9,7 +9,7 @@
 import HelloWorld from "./components/HelloWorld.vue";
 
 export default {
-  name: "Ethereum App",
+  name: "EthereumApp",
   components: {
     HelloWorld,
   },


### PR DESCRIPTION
I don't think this name is explicitly used anywhere so this should be sufficient.

fixes #57