### PR TITLE
Rename "dist" to "build" in Vue.js templates

### DIFF
--- a/handlebars/vue/packages/vue-app/scripts/ipfs.js
+++ b/handlebars/vue/packages/vue-app/scripts/ipfs.js
@@ -48,7 +48,7 @@ function nodeMayAllowPublish(ipfsClient) {
   console.log("🛰  Sending to IPFS...");
   console.log();
 
-  const { cid } = await pushDirectoryToIpfs("./dist");
+  const { cid } = await pushDirectoryToIpfs("./build");
   if (!cid) {
     console.log(`📡 App deployment failed`);
     return false;

--- a/handlebars/vue/packages/vue-app/vue.config.js
+++ b/handlebars/vue/packages/vue-app/vue.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   publicPath: "./",
+  outputDir: "build"
 };


### PR DESCRIPTION
This is completely untested although it's a super simple change (waiting on #76 so I can do a sanity check)

fixes #61