### PR TITLE
[useWeb3Modal] return object instead of array

### DIFF
--- a/handlebars/react/packages/react-app/src/App.js.hbs
+++ b/handlebars/react/packages/react-app/src/App.js.hbs
@@ -35,7 +35,7 @@ function WalletButton({ provider, loadWeb3Modal, logoutOfWeb3Modal }) {
 
 function App() {
   const { loading, error, data } = useQuery({{ graphqlQueryName }});
-  const [provider, loadWeb3Modal, logoutOfWeb3Modal] = useWeb3Modal();
+  const {provider, loadWeb3Modal, logoutOfWeb3Modal} = useWeb3Modal();
 
   React.useEffect(() => {
     {{#each hooks.readData }}

--- a/handlebars/react/packages/react-app/src/hooks/useWeb3Modal.js
+++ b/handlebars/react/packages/react-app/src/hooks/useWeb3Modal.js
@@ -11,7 +11,6 @@ const NETWORK_NAME = "mainnet";
 
 function useWeb3Modal(config = {}) {
   const [provider, setProvider] = useState();
-  const [account, setAccount] = useState('');
   const { autoLoad = true, infuraId = INFURA_ID, NETWORK = NETWORK_NAME } = config;
 
   // Web3Modal also supports many other wallets.
@@ -28,16 +27,6 @@ function useWeb3Modal(config = {}) {
       },
     },
   });
-
-  // get connected account address
-  useEffect(() => {
-    async function getAccount() {
-      const signer = provider.getSigner();
-      const gotAccount = await signer.getAddress();
-      setAccount(gotAccount);
-    }
-    provider && getAccount();
-  }, [provider]);
 
   // Open wallet selection modal.
   const loadWeb3Modal = useCallback(async () => {
@@ -64,7 +53,6 @@ function useWeb3Modal(config = {}) {
     provider,
     loadWeb3Modal,
     logoutOfWeb3Modal,
-    account
   };
 }
 

--- a/handlebars/react/packages/react-app/src/hooks/useWeb3Modal.js
+++ b/handlebars/react/packages/react-app/src/hooks/useWeb3Modal.js
@@ -11,6 +11,7 @@ const NETWORK_NAME = "mainnet";
 
 function useWeb3Modal(config = {}) {
   const [provider, setProvider] = useState();
+  const [account, setAccount] = useState('');
   const { autoLoad = true, infuraId = INFURA_ID, NETWORK = NETWORK_NAME } = config;
 
   // Web3Modal also supports many other wallets.
@@ -28,6 +29,16 @@ function useWeb3Modal(config = {}) {
     },
   });
 
+  // get connected account address
+  useEffect(() => {
+    async function getAccount() {
+      const signer = provider.getSigner();
+      const gotAccount = await signer.getAddress();
+      setAccount(gotAccount);
+    }
+    provider && getAccount();
+  }, [provider]);
+
   // Open wallet selection modal.
   const loadWeb3Modal = useCallback(async () => {
     const newProvider = await web3Modal.connect();
@@ -35,7 +46,7 @@ function useWeb3Modal(config = {}) {
   }, [web3Modal]);
 
   const logoutOfWeb3Modal = useCallback(
-    async function() {
+    async function () {
       await web3Modal.clearCachedProvider();
       window.location.reload();
     },
@@ -49,7 +60,12 @@ function useWeb3Modal(config = {}) {
     }
   }, [autoLoad, loadWeb3Modal, web3Modal.cachedProvider]);
 
-  return [provider, loadWeb3Modal, logoutOfWeb3Modal];
+  return {
+    provider,
+    loadWeb3Modal,
+    logoutOfWeb3Modal,
+    account
+  };
 }
 
 export default useWeb3Modal;


### PR DESCRIPTION
current return data `provider, loadWeb3Modal, logoutOfWeb3Modal` are unrelated, so it might be better to organize as an object than an array