### PR TITLE
refactor: dryify template tests

### DIFF
--- a/test/integration/templates.test.ts
+++ b/test/integration/templates.test.ts
@@ -8,7 +8,9 @@ import * as envHelpers from "../../src/helpers/env";
 import { FrameworkKey, TemplateKey, Templates } from "../../src/helpers/constants";
 import { downloadAndExtractTemplateContext, hasTemplate } from "../../src/helpers/templates";
 
-const templateTable = Templates.map(template => [template]);
+const templateTable = Templates.map(template => {
+  return [template]
+});
 
 describe("templates", function () {
   let getRefsMock: jest.SpyInstance;
@@ -27,7 +29,7 @@ describe("templates", function () {
     describe("when the framework = react", function () {
       const framework: FrameworkKey = "react";
 
-      describe.each(templateTable)(`when the template = %s`, function (template: TemplateKey) {
+      describe.each(templateTable)("when the template = %s", function (template: TemplateKey) {
         const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
 
         test("it works", async function () {
@@ -45,7 +47,7 @@ describe("templates", function () {
     describe("when the framework = vue", function () {
       const framework: FrameworkKey = "vue";
 
-      describe.each(templateTable)(`when the template = %s`, function (template: TemplateKey) {
+      describe.each(templateTable)("when the template = %s", function (template: TemplateKey) {
         const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
 
         test("it works", async function () {

--- a/test/integration/templates.test.ts
+++ b/test/integration/templates.test.ts
@@ -8,7 +8,7 @@ import * as envHelpers from "../../src/helpers/env";
 import { FrameworkKey, TemplateKey, Templates } from "../../src/helpers/constants";
 import { downloadAndExtractTemplateContext, hasTemplate } from "../../src/helpers/templates";
 
-const templateTable = Templates.map((template) => [template])
+const templateTable = Templates.map(template => [template]);
 
 describe("templates", function () {
   let getRefsMock: jest.SpyInstance;
@@ -26,7 +26,7 @@ describe("templates", function () {
 
     describe("when the framework = react", function () {
       const framework: FrameworkKey = "react";
-  
+
       describe.each(templateTable)(`when the template = %s`, function (template: TemplateKey) {
         const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
 

--- a/test/integration/templates.test.ts
+++ b/test/integration/templates.test.ts
@@ -9,7 +9,7 @@ import { FrameworkKey, TemplateKey, Templates } from "../../src/helpers/constant
 import { downloadAndExtractTemplateContext, hasTemplate } from "../../src/helpers/templates";
 
 const templateTable = Templates.map(template => {
-  return [template]
+  return [template];
 });
 
 describe("templates", function () {

--- a/test/integration/templates.test.ts
+++ b/test/integration/templates.test.ts
@@ -5,8 +5,10 @@ import { Result, compare } from "dir-compare";
 
 import * as envHelpers from "../../src/helpers/env";
 
-import { FrameworkKey, TemplateKey } from "../../src/helpers/constants";
+import { FrameworkKey, TemplateKey, Templates } from "../../src/helpers/constants";
 import { downloadAndExtractTemplateContext, hasTemplate } from "../../src/helpers/templates";
+
+const templateTable = Templates.map((template) => [template])
 
 describe("templates", function () {
   let getRefsMock: jest.SpyInstance;
@@ -24,9 +26,8 @@ describe("templates", function () {
 
     describe("when the framework = react", function () {
       const framework: FrameworkKey = "react";
-
-      describe("when the template = aave", function () {
-        const template: TemplateKey = "aave";
+  
+      describe.each(templateTable)(`when the template = %s`, function (template: TemplateKey) {
         const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
 
         test("it works", async function () {
@@ -39,193 +40,20 @@ describe("templates", function () {
           expect(result.same).toBe(true);
         });
       });
-
-      describe("when the template = compound", function () {
-        const template: TemplateKey = "compound";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = default", function () {
-        const template: TemplateKey = "default";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = kyber", function () {
-        const template: TemplateKey = "kyber";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = maker", function () {
-        const template: TemplateKey = "maker";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = sablier-v1", function () {
-        const template: TemplateKey = "sablier-v1";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = synthetix", function () {
-        const template: TemplateKey = "synthetix";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = uniswap-v1", function () {
-        const template: TemplateKey = "uniswap-v1";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = uniswap-v2", function () {
-        const template: TemplateKey = "uniswap-v2";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
     });
 
     describe("when the framework = vue", function () {
       const framework: FrameworkKey = "vue";
 
-      describe("when the template = aave", function () {
-        const template: TemplateKey = "aave";
+      describe.each(templateTable)(`when the template = %s`, function (template: TemplateKey) {
         const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
 
         test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = compound", function () {
-        const template: TemplateKey = "compound";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = default", function () {
-        const template: TemplateKey = "default";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = kyber", function () {
-        const template: TemplateKey = "kyber";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = maker", function () {
-        const template: TemplateKey = "maker";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = sablier-v1", function () {
-        const template: TemplateKey = "sablier-v1";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = synthetix", function () {
-        const template: TemplateKey = "synthetix";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = uniswap-v1", function () {
-        const template: TemplateKey = "uniswap-v1";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
-          const result: Result = await compare(sourceCodePath, testDirPath);
-          expect(result.same).toBe(true);
-        });
-      });
-
-      describe("when the template = uniswap-v2", function () {
-        const template: TemplateKey = "uniswap-v2";
-        const sourceCodePath: string = path.join(__dirname, "..", "..", "templates", framework, template);
-
-        test("it works", async function () {
-          await downloadAndExtractTemplateContext(testDirPath, framework, template);
+          try {
+            await downloadAndExtractTemplateContext(testDirPath, framework, template);
+          } catch (error) {
+            console.log({ error });
+          }
           const result: Result = await compare(sourceCodePath, testDirPath);
           expect(result.same).toBe(true);
         });

--- a/test/unit/directories.test.ts
+++ b/test/unit/directories.test.ts
@@ -5,6 +5,27 @@ import tempy from "tempy";
 
 import { isDirectoryEmpty } from "../../src/helpers/directories";
 
+const filesDirsTable: string[][] = [
+  [".DS_Store", "file"],
+  [".git", "directory"],
+  [".gitattributes", "file"],
+  [".gitignore", "file"],
+  [".gitlab-ci.yml", "file"],
+  [".hg", "directory"],
+  [".hgcheck", "file"],
+  [".hgignore", "file"],
+  [".idea", "directory"],
+  ["Thumbs.db", "file"],
+  [".travis.yml", "file"],
+  ["docs", "directory"],
+  ["LICENSE", "file"],
+  ["mkdocs.yml", "file"],
+  ["npm-debug.log", "file"],
+  ["yarn-debug.log", "file"],
+  ["yarn-error.log", "file"],
+  ["proj.iml", "file"],
+]
+
 describe("directories", function () {
   const appName: string = "my-eth-app";
   let testDirPath: string;
@@ -20,179 +41,13 @@ describe("directories", function () {
   });
 
   describe("when the directory is not empty", function () {
-    describe("when it contains a .DS_Store file", function () {
+    describe.each(filesDirsTable)("when it contains a %s %s", function (name: string, type: string) {
       beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, ".DS_Store"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a .git directory", function () {
-      beforeEach(async function () {
-        await fsExtra.mkdir(path.join(testDirPath, ".git"));
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a .gitattributes file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, ".gitattributes"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a .gitignore file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, ".gitignore"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a .gitlab-ci.yml file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, ".gitlab-ci.yml"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a .hg directory", function () {
-      beforeEach(async function () {
-        await fsExtra.mkdir(path.join(testDirPath, ".hg"));
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a .hgcheck file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, ".hgcheck"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a .hgignore file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, ".hgignore"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains an .idea folder", function () {
-      beforeEach(async function () {
-        await fsExtra.mkdir(path.join(testDirPath, ".idea"));
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a .travis.yml file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, ".travis.yml"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a LICENSE file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, "LICENSE"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a Thumbs.db file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, "Thumbs.db"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a docs directory", function () {
-      beforeEach(async function () {
-        await fsExtra.mkdir(path.join(testDirPath, "docs"));
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a mkdocs.yml file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, "mkdocs.yml"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a npm-debug.log file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, "npm-debug.log"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a yarn-debug.log file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, "yarn-debug.log"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains a yarn-error.log file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, "yarn-error.log"), "w");
-      });
-
-      test("returns true", async function () {
-        expect(isDirectoryEmpty(testDirPath, appName)).toBe(true);
-      });
-    });
-
-    describe("when it contains an proj.iml file", function () {
-      beforeEach(async function () {
-        await fsExtra.open(path.join(testDirPath, "proj.iml"), "w");
+        if (type === "file"){
+          await fsExtra.open(path.join(testDirPath, name), "w");
+        } else if (type === "directory"){
+          await fsExtra.mkdir(path.join(testDirPath, name));
+        }
       });
 
       test("returns true", async function () {

--- a/test/unit/directories.test.ts
+++ b/test/unit/directories.test.ts
@@ -5,6 +5,7 @@ import tempy from "tempy";
 
 import { isDirectoryEmpty } from "../../src/helpers/directories";
 
+// This has to be in sync with the valid files defined "helpers/directories".
 const filesDirsTable: string[][] = [
   [".DS_Store", "file"],
   [".git", "directory"],
@@ -41,7 +42,7 @@ describe("directories", function () {
   });
 
   describe("when the directory is not empty", function () {
-    describe.each(filesDirsTable)("when it contains a %s %s", function (name: string, type: string) {
+    describe.each(filesDirsTable)("when it contains a \"%s\" %s", function (name: string, type: string) {
       beforeEach(async function () {
         if (type === "file") {
           await fsExtra.open(path.join(testDirPath, name), "w");

--- a/test/unit/directories.test.ts
+++ b/test/unit/directories.test.ts
@@ -42,7 +42,7 @@ describe("directories", function () {
   });
 
   describe("when the directory is not empty", function () {
-    describe.each(filesDirsTable)("when it contains a \"%s\" %s", function (name: string, type: string) {
+    describe.each(filesDirsTable)('when it contains a "%s" %s', function (name: string, type: string) {
       beforeEach(async function () {
         if (type === "file") {
           await fsExtra.open(path.join(testDirPath, name), "w");

--- a/test/unit/directories.test.ts
+++ b/test/unit/directories.test.ts
@@ -24,7 +24,7 @@ const filesDirsTable: string[][] = [
   ["yarn-debug.log", "file"],
   ["yarn-error.log", "file"],
   ["proj.iml", "file"],
-]
+];
 
 describe("directories", function () {
   const appName: string = "my-eth-app";
@@ -43,9 +43,9 @@ describe("directories", function () {
   describe("when the directory is not empty", function () {
     describe.each(filesDirsTable)("when it contains a %s %s", function (name: string, type: string) {
       beforeEach(async function () {
-        if (type === "file"){
+        if (type === "file") {
           await fsExtra.open(path.join(testDirPath, name), "w");
-        } else if (type === "directory"){
+        } else if (type === "directory") {
           await fsExtra.mkdir(path.join(testDirPath, name));
         }
       });


### PR DESCRIPTION
Sorry for not giving a timely review on #86 @PaulRBerg.

I've had a look through and replaced the individual `describe` blocks for each template with `describe.each` so to reduce the amount of maintenance on tests as we add new templates. New test cases will be generated for all templates described in `src/helpers/constants`