### PR TITLE
docs: update link for grant funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
- 
+
 # These are supported funding model platforms
 
-custom: ["https://gitcoin.co/grants/943/create-eth-app"]
+custom: ["https://gitcoin.co/grants/1657/paulrberg-open-source-engineering"]


### PR DESCRIPTION
I am now using [this grant](https://gitcoin.co/grants/1657/paulrberg-open-source-engineering) as the funding mechanism for CEA.