### PR TITLE
fix console warning 'body' nested inside 'div'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2021-05-4
+
+### Fixed
+
+- Warning caused by duplicate "body" tag, which fixes [issue #55](https://github.com/paulrberg/create-eth-app/issues/55)
+
 ## [1.6.2] - 2020-12-20
 
 ### Fixed
@@ -158,6 +164,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of the tool
 - The default template
 
+[1.6.3]: https://github.com/paulrberg/create-eth-app/compare/v1.6.2...v1.6.3
+[1.6.2]: https://github.com/paulrberg/create-eth-app/compare/v1.6.1...v1.6.2
+[1.6.1]: https://github.com/paulrberg/create-eth-app/compare/v1.5.0...v1.6.1
+[1.5.0]: https://github.com/paulrberg/create-eth-app/compare/v1.4.1...v1.5.0
+[1.4.1]: https://github.com/paulrberg/create-eth-app/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/paulrberg/create-eth-app/compare/v1.3.1...v1.4.0
+[1.3.1]: https://github.com/paulrberg/create-eth-app/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/paulrberg/create-eth-app/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/paulrberg/create-eth-app/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/paulrberg/create-eth-app/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/paulrberg/create-eth-app/compare/v1.0.0...v1.1.0

--- a/handlebars/react/packages/react-app/src/components/index.js
+++ b/handlebars/react/packages/react-app/src/components/index.js
@@ -10,7 +10,7 @@ export const Header = styled.header`
   color: white;
 `;
 
-export const Body = styled.body`
+export const Body = styled.div`
   align-items: center;
   background-color: #282c34;
   color: white;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-eth-app",
   "description": "Create Ethereum-powered apps with one command",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "bin": {
     "create-eth-app": "./dist/index.js"
   },


### PR DESCRIPTION
The current DOM had body-div-div-body and was logging this error in the console. Easy fix was to change the nested `Body` into a `div` on the styled component

> index.js:1 Warning: validateDOMNesting(...): <body> cannot appear as a child of <div>.
    in body (created by styled.body)
    in styled.body (at App.js:55)
    in div (at App.js:51)
    in App (at src/index.js:16)
    in ApolloProvider (at src/index.js:15)
    
    
<img width="393" alt="body-div-body_2021-05-13_00-03-39" src="https://user-images.githubusercontent.com/764988/118091341-8ba50b80-b37f-11eb-8bdd-f7444ab28afe.png">
