### PR TITLE
chore: update README with latest node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ When you’re ready to deploy to production, create a minified bundle with `yarn
 
 ## Creating an App
 
-**You’ll need to have Node 8.16.0 or Node 10.16.0 or later version on your local development machine** (but it’s not required on the server). You can use [nvm](https://github.com/creationix/nvm#installation) (macOS/Linux) or [nvm-windows](https://github.com/coreybutler/nvm-windows#node-version-manager-nvm-for-windows) to switch Node versions between different projects.
+**You’ll need to have Node 14 or later version on your local development machine** (but it’s not required on the server). You can use [nvm](https://github.com/creationix/nvm#installation) (macOS/Linux) or [nvm-windows](https://github.com/coreybutler/nvm-windows#node-version-manager-nvm-for-windows) to switch Node versions between different projects.
 
 **You'll also need Yarn on your local development machine**. This is because Create Eth App relies on Yarn
 Workspaces, a feature not supported by Npm.


### PR DESCRIPTION
Update README to reference the correct dependency on node >14 to run through a fresh install.  