### PR TITLE
Fix Ci integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "prompts": "^2.4.2",
     "tar": "^6.1.11",
     "update-check": "^1.5.4",
-    "url-exist": "2.0.2",
     "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {

--- a/src/helpers/frameworks.ts
+++ b/src/helpers/frameworks.ts
@@ -2,10 +2,10 @@ import fsExtra from "fs-extra";
 import got from "got";
 import promisePipe from "promisepipe";
 import tar from "tar";
-import urlExists from "url-exist";
 
 import { codeloadBaseUrl, githubApiBaseUrl } from "./constants";
 import { getRefs, getRepository } from "./env";
+import { urlExists } from "./url";
 
 export async function downloadAndExtractFrameworkHandlebars(root: string, framework: string): Promise<void> {
   await fsExtra.ensureDir(root);

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -4,7 +4,6 @@ import Handlebars from "handlebars";
 import path from "path";
 import promisePipe from "promisepipe";
 import tar from "tar";
-import urlExists from "url-exist";
 
 import {
   FrameworkKey,
@@ -15,6 +14,7 @@ import {
   githubApiBaseUrl,
 } from "./constants";
 import { getRefs, getRepository } from "./env";
+import { urlExists } from "./url";
 
 export async function downloadAndExtractTemplateContext(
   root: string,

--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,0 +1,14 @@
+import https from "https";
+
+export const urlExists = (url: string): Promise<boolean> =>
+  new Promise(resolve => {
+    https.get(
+      url,
+      {
+        headers: {
+          "User-Agent": "create-eth-app",
+        },
+      },
+      res => resolve(res.statusCode === 200),
+    );
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3209,15 +3209,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abort-controller@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "abort-controller@npm:3.0.0"
-  dependencies:
-    event-target-shim: ^5.0.0
-  checksum: 170bdba9b47b7e65906a28c8ce4f38a7a369d78e2271706f020849c1bfe0ee2067d4261df8bbb66eb84f79208fd5b710df759d64191db58cfba7ce8ef9c54b75
-  languageName: node
-  linkType: hard
-
 "acorn-globals@npm:^6.0.0":
   version: 6.0.0
   resolution: "acorn-globals@npm:6.0.0"
@@ -4718,7 +4709,6 @@ __metadata:
     ts-jest: ^27.1.3
     typescript: ~4.6.2
     update-check: ^1.5.4
-    url-exist: 2.0.2
     validate-npm-package-name: ^3.0.0
   bin:
     create-eth-app: ./dist/index.js
@@ -5545,13 +5535,6 @@ __metadata:
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
-  languageName: node
-  linkType: hard
-
-"event-target-shim@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "event-target-shim@npm:5.0.1"
-  checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
   languageName: node
   linkType: hard
 
@@ -6922,13 +6905,6 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"ip-regex@npm:^4.1.0":
-  version: 4.3.0
-  resolution: "ip-regex@npm:4.3.0"
-  checksum: 7ff904b891221b1847f3fdf3dbb3e6a8660dc39bc283f79eb7ed88f5338e1a3d1104b779bc83759159be266249c59c2160e779ee39446d79d4ed0890dfd06f08
-  languageName: node
-  linkType: hard
-
 "ip@npm:^1.1.5":
   version: 1.1.5
   resolution: "ip@npm:1.1.5"
@@ -7282,15 +7258,6 @@ fsevents@^2.3.2:
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 3508c6cd0a9ee2e0df2fa2e9baabcdc89e911c7bd5cf64604586697212feec525aa21050e48affb5ffc3df20f0f5d2e2cf79b08caa64e1ccc9578e251763aef7
-  languageName: node
-  linkType: hard
-
-"is-url-superb@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-url-superb@npm:3.0.0"
-  dependencies:
-    url-regex: ^5.0.0
-  checksum: 5d1f9a945327b997fbfb3aafa18ccefe81b7a60b7101cd84d6fbd7321da738a45fb29447fa68de64324003d32bb1fbcb54cb68ee0f458c6fd4b5982feca70f9a
   languageName: node
   linkType: hard
 
@@ -8184,29 +8151,6 @@ fsevents@^2.3.2:
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
   checksum: df82cd1e172f957bae9c536286265a5cdbd5eeca487cb0a3b2a7b41ef959fc61f8e7c0e9aeea9c114ccf2c166b6a8dd45a46fd619c1c569d210ecd2765ad5169
-  languageName: node
-  linkType: hard
-
-"ky-universal@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "ky-universal@npm:0.5.0"
-  dependencies:
-    abort-controller: ^3.0.0
-    node-fetch: ^2.6.0
-  peerDependencies:
-    ky: ">=0.17.0"
-    web-streams-polyfill: ">=2.0.0"
-  peerDependenciesMeta:
-    web-streams-polyfill:
-      optional: true
-  checksum: 9ad9f7ca4930cf93b1aee97c4ab1738b9962ad3cb8ae153975854f0612af1184cc5a628b1d19c9b83124364af5520f91a911685723f89588f4b39a7e544a498c
-  languageName: node
-  linkType: hard
-
-"ky@npm:^0.19.0":
-  version: 0.19.1
-  resolution: "ky@npm:0.19.1"
-  checksum: 38838153fc52b10759e53893739aeb37be3705da0843ae366d71a822c1bd5bf522d52eb46fdd7ea579ff0a1185082b1f50633ba11ece27e51b081db98dacce96
   languageName: node
   linkType: hard
 
@@ -9114,7 +9058,14 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "node-fetch@npm:2.6.1"
+  checksum: 91075bedd57879117e310fbcc36983ad5d699e522edb1ebcdc4ee5294c982843982652925c3532729fdc86b2d64a8a827797a745f332040d91823c8752ee4d7c
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -9125,13 +9076,6 @@ fsevents@^2.3.2:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.1":
-  version: 2.6.1
-  resolution: "node-fetch@npm:2.6.1"
-  checksum: 91075bedd57879117e310fbcc36983ad5d699e522edb1ebcdc4ee5294c982843982652925c3532729fdc86b2d64a8a827797a745f332040d91823c8752ee4d7c
   languageName: node
   linkType: hard
 
@@ -11791,15 +11735,6 @@ resolve@^1.3.2:
   languageName: node
   linkType: hard
 
-"tlds@npm:^1.203.0":
-  version: 1.230.0
-  resolution: "tlds@npm:1.230.0"
-  bin:
-    tlds: bin.js
-  checksum: a1aa4e7a8887c197bf7ad4e739bee1672502aa9cb5e6e2c68ba319495988824044a1549332d284420deb14680a745179e955db13ff2ba69eef1d3850a32967ca
-  languageName: node
-  linkType: hard
-
 "tmp@npm:^0.0.33":
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
@@ -12327,27 +12262,6 @@ typescript@^4.4.3:
   version: 0.1.0
   resolution: "urix@npm:0.1.0"
   checksum: 4c076ecfbf3411e888547fe844e52378ab5ada2d2f27625139011eada79925e77f7fbf0e4016d45e6a9e9adb6b7e64981bd49b22700c7c401c5fc15f423303b3
-  languageName: node
-  linkType: hard
-
-"url-exist@npm:2.0.2":
-  version: 2.0.2
-  resolution: "url-exist@npm:2.0.2"
-  dependencies:
-    is-url-superb: ^3.0.0
-    ky: ^0.19.0
-    ky-universal: ^0.5.0
-  checksum: fe2c4818d1365eee1c1978f40e4b759aa92e94ad8413930e4ac4226c67df34a12fa7ccd723463ae36ae493b0e79a8877961420eb70fe6947a7122c863db2651e
-  languageName: node
-  linkType: hard
-
-"url-regex@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "url-regex@npm:5.0.0"
-  dependencies:
-    ip-regex: ^4.1.0
-    tlds: ^1.203.0
-  checksum: 94f63ddd39bbc935fa3ee34ab496e1a62b2b6826982e5f7515b8b52acd6439e489d78fc2e202ab4585e0a5cc9cceca15993206153213affa928c41ce819e055c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/PaulRBerg/create-eth-app/issues/238

* integration tests were failing because GitHub was blocking the `HEAD` requests with `403` error
  * Adding a `User-Agent` header unblocks it.
* replace `url-exist` library with inbuilt nodejs [https module](https://nodejs.org/docs/latest-v14.x/api/https.html)

```bash
$ yarn test:integration
 PASS  test/integration/frameworks.test.ts (7.269 s)
 PASS  test/integration/templates.test.ts (33.703 s)

Test Suites: 2 passed, 2 total
Tests:       35 passed, 35 total
Snapshots:   0 total
Time:        33.87 s
Ran all test suites matching /test\/integration/i.
```